### PR TITLE
Add note for Windows users on single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ And load it in your build process in your ```package.json```:
   },
 ```
 
+#### Note for Windows users
+
+If running on Windows, make sure to [replace the single quotes with escaped double quotes](https://github.com/keithamus/npm-scripts-example/issues/5#issuecomment-70134543):
+```json
+  "scripts": {
+    "build": "npm-html2js -i \"files/**/*.html\" -o \"dist/template.js\""
+  },
+```
 
 ### Options
 


### PR DESCRIPTION
Using single quotes (as suggested in the docs) for the command-line parameters on Windows causes the script not to generate an output.

I have wasted a couple of hours before realising what was causing the problem. This might prevent other people from falling into the same trap.
